### PR TITLE
Dev/fix subset script not generating image indicator tables

### DIFF
--- a/data_preparation_tools/cp6/tables/image_indicator_table.py
+++ b/data_preparation_tools/cp6/tables/image_indicator_table.py
@@ -41,8 +41,6 @@ class ImageIndicatorTable:
     def write_to_file( self, fn, id_list = None ):
         if not id_list:
             id_list = sorted( self.image_indicators.keys() )
-        else:
-            sys.stderr.write( 'Debug: %s passed %d id_list' % (fn, len(id_list)))
         with open( fn, 'w' ) as f:
             for mir_id in sorted( id_list ):
                 imgind = self.image_indicators[ mir_id ]

--- a/data_preparation_tools/tools/cp6_subset.py
+++ b/data_preparation_tools/tools/cp6_subset.py
@@ -43,6 +43,7 @@ import random
 
 from cp6.tables.edge_table import EdgeTable
 from cp6.tables.image_table import ImageTable
+from cp6.tables.image_indicator_table import ImageIndicatorTable
 
 #
 # src is a fully populated sandbox. given a set of image IDs (aka nodes)
@@ -339,6 +340,15 @@ if __name__ == '__main__':
     w.downsample_feature_files( 'run_testing', ids.ids_test.ids )
     # ...training
     w.downsample_feature_files( 'run_training', ids.ids_train.ids )
+
+    # image indicator tables:
+    # ...testing
+    iit_train = ImageIndicatorTable.read_from_file( os.path.join( w.src.dirs['run_training'], 'image_indicator_table.txt' ))
+    iit_train.write_to_file( os.path.join( w.dst.dirs['run_training'], 'image_indicator_table.txt' ), ids.ids_train.ids )
+    sys.stderr.write( 'Downsampled training image_indicator_table\n' )
+    iit_test = ImageIndicatorTable.read_from_file( os.path.join( w.src.dirs['run_testing'], 'image_indicator_table.txt' ))
+    iit_test.write_to_file( os.path.join( w.dst.dirs['run_testing'], 'image_indicator_table.txt' ), ids.ids_test.ids )
+    sys.stderr.write( 'Downsampled testing image_indicator_table\n' )
 
     ## all done!
 

--- a/data_preparation_tools/tools/cp6_subset.py
+++ b/data_preparation_tools/tools/cp6_subset.py
@@ -327,7 +327,7 @@ if __name__ == '__main__':
     # ...testing table
     w.downsample_image_file( w.image_table_test, 'run_testing', ids.ids_test.ids , True )
     # ....training
-    w.downsample_image_file( w.image_table_train, 'run_training', ids.ids_train.ids , True )
+    w.downsample_image_file( w.image_table_train, 'run_training', ids.ids_train.ids , False )
 
     # edge tables:
     # ...testing


### PR DESCRIPTION
This patches the subset script to generate correctly downsampled image_indicator_table files, so that subsets can be successfully converted into McAuley's input files via the sandbox_adapter script.
