### PR TITLE
Dev/small tweaks to sandbox code

### DIFF
--- a/data_preparation_tools/baseline-svm/sandbox_adapter.py
+++ b/data_preparation_tools/baseline-svm/sandbox_adapter.py
@@ -566,13 +566,13 @@ double BMRM.lambda 0.001
             sys.stderr.write('Info: wrote %s\n' % conf_fn )
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        sys.stderr.write('Usage: $0 output-dir\n')
+    if len(sys.argv) != 3:
+        sys.stderr.write('Usage: $0 input-dir output-dir\n')
         sys.exit(1)
-    out_dir = (sys.argv[1])
+    out_dir = (sys.argv[2])
     if not os.path.isdir( out_dir ):
         os.mkdir(out_dir)
 
-    s = SandboxAdapter('.')
+    s = SandboxAdapter(sys.argv[1])
     s.load()
     s.write( out_dir )

--- a/data_preparation_tools/tools/cp6_subset.py
+++ b/data_preparation_tools/tools/cp6_subset.py
@@ -242,7 +242,11 @@ class IDSelectorSource:
             if self.n > len(image_table.entries):
                 sys.stderr.write('ERROR: %s id source requested more samples than available; exiting\n' % self.which)
                 sys.exit(1)
-            self.ids = random.sample( image_table.entries.keys(), self.n )
+            if self.n == len(image_table.entries):
+                sys.stderr.write('Info: 100% of entries requested\n')
+                self.ids = image_table.entries.keys()
+            else:
+                self.ids = random.sample( image_table.entries.keys(), self.n )
 
 class IDSelector:
     def __init__( self, s ):


### PR DESCRIPTION
This branch makes few tweaks to the sandbox code:

- the sandbox_adapter script now requires an input-dir; previously, you had to run it from the root of the source sandbox.

- The subset tool now detects if you specify '100p' (100 percent) of the testing and/or training IDs, and just copies those files over (which is equivalent to, but much faster than, reading, selecting them all, and writing them back out.)
